### PR TITLE
UX: use standard format locale codes (e.g., zh-TW)

### DIFF
--- a/about.json
+++ b/about.json
@@ -1,8 +1,7 @@
 {
   "about_url": null,
   "license_url": null,
-  "assets": {
-  },
-  "name": "localized header",
+  "assets": {},
+  "name": "Localized Header",
   "component": true
 }

--- a/javascripts/discourse/components/localized-header.js
+++ b/javascripts/discourse/components/localized-header.js
@@ -13,7 +13,7 @@ export default Component.extend({
   @discourseComputed
   foundLocale() {
     let filteredLocale = this.parsedSetting.filter(
-      (obj) => obj.locale === I18n.currentLocale()
+      (obj) => obj.locale === I18n.currentLocale().replace(/_/g, "-")
     );
 
     if (!filteredLocale.length) {

--- a/settings.yml
+++ b/settings.yml
@@ -1,7 +1,7 @@
 nav_links:
   default: >-
     [{}]
-  json_schema: '{"type":"array","format":"list","uniqueItems":true,"items":{"type":"object","properties":{"locale":{"type":"string"},"links":{"type":"array","format":"table","uniqueItems":true,"items":{"type":"object","properties":{"link_text":{"type":"string"},"link":{"type":"string"},"sublinks":{"type":"array","format":"table","uniqueItems":true,"items":{"type":"object","properties":{"link_text":{"type":"string"},"link":{"type":"string"}},"additionalProperties":false}}},"additionalProperties":false}}},"additionalProperties":false}}'
+  json_schema: '{"type":"array","format":"list","uniqueItems":true,"items":{"type":"object","properties":{"locale":{"type":"string", "description": "standard language codes, for example en, fr, zh-TW, etc"},"links":{"type":"array","format":"table","uniqueItems":true,"items":{"type":"object","properties":{"link_text":{"type":"string"},"link":{"type":"string"},"sublinks":{"type":"array","format":"table","uniqueItems":true,"items":{"type":"object","properties":{"link_text":{"type":"string"},"link":{"type":"string"}},"additionalProperties":false}}},"additionalProperties":false}}},"additionalProperties":false}}'
 
 logged_in_url:
   default: "/my/preferences/interface"


### PR DESCRIPTION
This updates to the IETF/ISO formatting (i.e., `zh-TW` instead of Discourse's slightly different `zh_TW`): https://en.wikipedia.org/wiki/IETF_language_tag#ISO_3166-1_and_UN_M.49