### PR TITLE
FIX: mobile overlap, special characters in classes

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -12,7 +12,11 @@
   top: 0;
   z-index: 1001;
   height: var(--localized-header-offset-height);
-  -webkit-transform: translate3d(0,0,0); // reduces icon jitter on scroll in iOS Safari
+  -webkit-transform: translate3d(
+    0,
+    0,
+    0
+  ); // reduces icon jitter on scroll in iOS Safari
 
   padding: 0 20px; // matches core wrap
   display: flex;

--- a/common/common.scss
+++ b/common/common.scss
@@ -2,12 +2,17 @@
   --localized-header-offset-height: 2em;
 }
 
+.d-header-wrap.custom-menu-open {
+  z-index: 1001;
+}
+
 .localized-header-connector {
   background: var(--header_background);
   position: sticky;
   top: 0;
   z-index: 1001;
   height: var(--localized-header-offset-height);
+  -webkit-transform: translate3d(0,0,0); // reduces icon jitter on scroll in iOS Safari
 
   padding: 0 20px; // matches core wrap
   display: flex;
@@ -45,12 +50,6 @@
       // submenu positioning
       ul {
         right: 0;
-      }
-    }
-
-    @media screen and (max-width: 600px) {
-      &:not(:last-child) {
-        display: none;
       }
     }
 

--- a/javascripts/discourse/api-initializers/mobile-header-zindex.js
+++ b/javascripts/discourse/api-initializers/mobile-header-zindex.js
@@ -6,16 +6,24 @@ import { withPluginApi } from "discourse/lib/plugin-api";
 export default {
   name: "mobile-header-zindex",
   initialize() {
-      withPluginApi("0.8", (api) => {
-        api.decorateWidget('header:after', helper => {
-          if (helper.widget.site.mobileView) {
-            if (helper.state.hamburgerVisible || helper.state.searchVisible || helper.state.userVisible ) {
-            document.querySelector(".d-header-wrap").classList.add("custom-menu-open");
-            } else {
-            document.querySelector(".d-header-wrap").classList.remove("custom-menu-open");
-            }
+    withPluginApi("0.8", (api) => {
+      api.decorateWidget("header:after", (helper) => {
+        if (helper.widget.site.mobileView) {
+          if (
+            helper.state.hamburgerVisible ||
+            helper.state.searchVisible ||
+            helper.state.userVisible
+          ) {
+            document
+              .querySelector(".d-header-wrap")
+              .classList.add("custom-menu-open");
+          } else {
+            document
+              .querySelector(".d-header-wrap")
+              .classList.remove("custom-menu-open");
           }
-        });
+        }
       });
+    });
   },
 };

--- a/javascripts/discourse/api-initializers/mobile-header-zindex.js
+++ b/javascripts/discourse/api-initializers/mobile-header-zindex.js
@@ -1,0 +1,21 @@
+// For mobile, we need to alter the z-index of the header when the menus are open
+// otherwise the custom menu will appear above the menus
+
+import { withPluginApi } from "discourse/lib/plugin-api";
+
+export default {
+  name: "mobile-header-zindex",
+  initialize() {
+      withPluginApi("0.8", (api) => {
+        api.decorateWidget('header:after', helper => {
+          if (helper.widget.site.mobileView) {
+            if (helper.state.hamburgerVisible || helper.state.searchVisible || helper.state.userVisible ) {
+            document.querySelector(".d-header-wrap").classList.add("custom-menu-open");
+            } else {
+            document.querySelector(".d-header-wrap").classList.remove("custom-menu-open");
+            }
+          }
+        });
+      });
+  },
+};

--- a/javascripts/discourse/components/localized-header.js
+++ b/javascripts/discourse/components/localized-header.js
@@ -16,17 +16,17 @@ export default Component.extend({
       (obj) => obj.locale === I18n.currentLocale().replace(/_/g, "-")
     );
 
-    // remove special chars, spaces, from link class
-    filteredLocale[0].links.forEach((link) => {
-      link.link_class = dasherize(link.link_text.replace(/[^a-zA-Z]/, ""));
-    });
-
     if (!filteredLocale.length) {
       // default to language if no locale set
       filteredLocale = this.parsedSetting.filter(
         (obj) => obj.locale === settings.fallback_language
       );
     }
+
+    // remove special chars, spaces, from link class
+    filteredLocale[0].links.forEach((link) => {
+      link.link_class = dasherize(link.link_text.replace(/[^a-zA-Z]/, ""));
+    });
 
     return filteredLocale[0];
   },

--- a/javascripts/discourse/components/localized-header.js
+++ b/javascripts/discourse/components/localized-header.js
@@ -18,9 +18,8 @@ export default Component.extend({
 
     // remove special chars, spaces, from link class
     filteredLocale[0].links.forEach((link) => {
-      link.link_class = dasherize(link.link_text.replace(/[^a-zA-Z]/, ''));
+      link.link_class = dasherize(link.link_text.replace(/[^a-zA-Z]/, ""));
     });
-
 
     if (!filteredLocale.length) {
       // default to language if no locale set

--- a/javascripts/discourse/components/localized-header.js
+++ b/javascripts/discourse/components/localized-header.js
@@ -16,6 +16,12 @@ export default Component.extend({
       (obj) => obj.locale === I18n.currentLocale().replace(/_/g, "-")
     );
 
+    // remove special chars, spaces, from link class
+    filteredLocale[0].links.forEach((link) => {
+      link.link_class = dasherize(link.link_text.replace(/[^a-zA-Z]/, ''));
+    });
+
+
     if (!filteredLocale.length) {
       // default to language if no locale set
       filteredLocale = this.parsedSetting.filter(
@@ -58,29 +64,29 @@ export default Component.extend({
 
   @action
   toggleHelp(link) {
-    let dashClass;
+    let linkClass;
 
-    if (link !== "global-menu") {
-      dashClass = dasherize(link.link_text);
+    if (link != "global-menu") {
+      linkClass = link.link_class
       if (!link.sublinks.length) {
         return;
       }
     } else {
-      dashClass = "global-menu";
+      linkClass = "global-menu";
     }
 
     document
-      .querySelectorAll(`.localized-header-nav-parent:not(.${dashClass})`)
+      .querySelectorAll(`.localized-header-nav-parent:not(.${linkClass})`)
       .forEach((element) => element.classList.remove("localized-nav-open"));
 
     document
-      .querySelectorAll(`.localized-header-nav-parent:not(.${dashClass}) > ul`)
+      .querySelectorAll(`.localized-header-nav-parent:not(.${linkClass}) > ul`)
       .forEach((element) => element.classList.add("hidden"));
 
-    let buildClass = `.localized-header-nav-parent.${dashClass} > ul`;
+    let buildClass = `.localized-header-nav-parent.${linkClass} > ul`;
 
     document
-      .querySelector(`.localized-header-nav-parent.${dashClass}`)
+      .querySelector(`.localized-header-nav-parent.${linkClass}`)
       .classList.toggle("localized-nav-open");
 
     document.querySelector(buildClass).classList.toggle("hidden");

--- a/javascripts/discourse/components/localized-header.js
+++ b/javascripts/discourse/components/localized-header.js
@@ -66,8 +66,8 @@ export default Component.extend({
   toggleHelp(link) {
     let linkClass;
 
-    if (link != "global-menu") {
-      linkClass = link.link_class
+    if (link !== "global-menu") {
+      linkClass = link.link_class;
       if (!link.sublinks.length) {
         return;
       }

--- a/javascripts/discourse/templates/components/localized-header.hbs
+++ b/javascripts/discourse/templates/components/localized-header.hbs
@@ -1,9 +1,8 @@
 <ul class="localized-header-nav">
   {{#each foundLocale.links as |l|}}
     <li
-      data-divider={{theme-setting "nav_divider"}}
-      class="{{if l.sublinks "localized-header-nav-parent"}}
-        {{dasherize l.link_text}}"
+      data-divider="{{theme-setting 'nav_divider'}}"
+      class="{{if l.sublinks 'localized-header-nav-parent'}} {{l.link_class}}"
     >
       <a
         href={{unless l.sublinks l.link}}

--- a/javascripts/discourse/templates/components/localized-header.hbs
+++ b/javascripts/discourse/templates/components/localized-header.hbs
@@ -1,8 +1,8 @@
 <ul class="localized-header-nav">
   {{#each foundLocale.links as |l|}}
     <li
-      data-divider="{{theme-setting 'nav_divider'}}"
-      class="{{if l.sublinks 'localized-header-nav-parent'}} {{l.link_class}}"
+      data-divider={{theme-setting "nav_divider"}}
+      class="{{if l.sublinks "localized-header-nav-parent"}} {{l.link_class}}"
     >
       <a
         href={{unless l.sublinks l.link}}


### PR DESCRIPTION
This fixes some customer reported issues. 

Special characters in nav names were causing issues, as the nav names are used for classes, so I added some regex to remove them. 

On mobile, the header menus would overlap the custom menu due to z-index issues. To workaround it I have to add a class to the header when the menus are open and adjust the z-index. 


![Screen Shot 2022-06-24 at 12 08 47 PM](https://user-images.githubusercontent.com/1681963/175574995-e17745eb-c4f3-4fa4-b57f-f517c0295dde.png)

