### PR TITLE
UX: remove old header offset adjustment

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -1,5 +1,5 @@
 .d-header-wrap {
-  top: 2.7em; // height of localized header
+  top: 2.86em; // height of localized header
   &.custom-menu-open {
     z-index: 1001;
   }

--- a/common/common.scss
+++ b/common/common.scss
@@ -1,9 +1,8 @@
-:root {
-  --localized-header-offset-height: 2em;
-}
-
-.d-header-wrap.custom-menu-open {
-  z-index: 1001;
+.d-header-wrap {
+  top: 2.7em; // height of localized header
+  &.custom-menu-open {
+    z-index: 1001;
+  }
 }
 
 .localized-header-connector {
@@ -11,7 +10,6 @@
   position: sticky;
   top: 0;
   z-index: 1001;
-  height: var(--localized-header-offset-height);
   -webkit-transform: translate3d(
     0,
     0,
@@ -25,10 +23,6 @@
     width: 100%;
     max-width: 1100px;
     margin: 0 auto;
-  }
-
-  + .d-header-wrap {
-    top: var(--localized-header-offset-height);
   }
 }
 


### PR DESCRIPTION
We updated the way the header height is calculated in core so this is no longer needed and causes some problems: 

![Screenshot 2023-07-17 at 4 37 08 PM](https://github.com/discourse/discourse-localized-header-nav/assets/1681963/ba417a1a-06ad-4283-bedc-fdbf0c2e4230)
